### PR TITLE
feat: adiciona liquibase para versionamento de tabelas/views

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,12 @@ Módulo responsável por ler arquivos de gastos de todas as partes da União pre
    ```bash
    git clone https://github.com/brasil-transparente/brasil-transparente-processor.git
    ```
-2. Crie a estrutura do banco no MySQL utilizando a query `create database gastos;`.
-3. Copie os arquivos de gastos da União do Drive (link abaixo) para a pasta do projeto.
-4. Certifique-se de que os paths no projeto estão apontando para o local correto dos arquivos.
-5. Certifique-se de que os dados do banco de dados local estão corretos no application.properties.
-6. Suba a aplicação utilizando o SpringBoot, executando a classe BrasilTransparenteProcessorApplication.
-7. Chame o Controller utilizando o POST ( /processYear={ano} ) e passando o ano de 2024.
-8. Se tudo estiver correto, a aplicação irá ler todos os arquivos e salvar no banco local todos os dados.
+2. Copie os arquivos de gastos da União do Drive (link abaixo) para a pasta do projeto.
+3. Certifique-se de que os paths no projeto estão apontando para o local correto dos arquivos.
+4. Certifique-se de que os dados do banco de dados local estão corretos no application.properties.
+5. Suba a aplicação utilizando o SpringBoot, executando a classe BrasilTransparenteProcessorApplication.
+6. Chame o Controller utilizando o POST ( /processYear={ano} ) e passando o ano de 2024.
+7. Se tudo estiver correto, a aplicação irá ler todos os arquivos e salvar no banco local todos os dados.
 
 📁 Link para o Drive: https://drive.google.com/drive/folders/1EvbRIqP9Eg8dZJP6RKSpf7KoippdhC3c?usp=drive_link
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Módulo responsável por ler arquivos de gastos de todas as partes da União pre
    ```bash
    git clone https://github.com/brasil-transparente/brasil-transparente-processor.git
    ```
-2. Crie a estrutura do banco no MySQL utilizando a query no arquivo table_setup.sql, localizado no Drive (link abaixo).
+2. Crie a estrutura do banco no MySQL utilizando a query `create database gastos;`.
 3. Copie os arquivos de gastos da União do Drive (link abaixo) para a pasta do projeto.
 4. Certifique-se de que os paths no projeto estão apontando para o local correto dos arquivos.
 5. Certifique-se de que os dados do banco de dados local estão corretos no application.properties.

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
     // Lombok
     implementation 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
+    // Liquibase
+    implementation 'org.liquibase:liquibase-core'
 }
 
 application {

--- a/src/main/java/com/brasil/transparente/processor/config/DatabaseConfig.java
+++ b/src/main/java/com/brasil/transparente/processor/config/DatabaseConfig.java
@@ -1,0 +1,59 @@
+package com.brasil.transparente.processor.config;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import javax.sql.DataSource;
+
+// essa classe executa antes da execução dos changelogs
+@Configuration
+public class DatabaseConfig {
+
+    @Value("${spring.datasource.url}")
+    private String datasourceUrl;
+
+    @Value("${spring.datasource.username}")
+    private String username;
+
+    @Value("${spring.datasource.password}")
+    private String password;
+
+    @Bean
+    public DataSource dataSource() throws SQLException {
+        String baseUrl = extractBaseUrl(datasourceUrl);
+
+        createDatabaseIfNotExists(baseUrl);
+
+        return createHikariDataSource();
+    }
+
+    private String extractBaseUrl(String url) {
+        return url.substring(0, url.lastIndexOf('/')) + "/";
+    }
+
+    private void createDatabaseIfNotExists(String baseUrl) throws SQLException {
+        try (Connection conn = DriverManager.getConnection(baseUrl, username, password);
+             Statement stmt = conn.createStatement()) {
+
+            String dbName = extractDatabaseName(datasourceUrl);
+            stmt.executeUpdate("CREATE DATABASE IF NOT EXISTS " + dbName);
+        }
+    }
+
+    private String extractDatabaseName(String url) {
+        return url.substring(url.lastIndexOf('/') + 1);
+    }
+
+    private DataSource createHikariDataSource() {
+        HikariDataSource dataSource = new HikariDataSource();
+        dataSource.setJdbcUrl(datasourceUrl);
+        dataSource.setUsername(username);
+        dataSource.setPassword(password);
+        return dataSource;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,5 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.properties.hibernate.format_sql=false
 spring.jpa.show-sql=false
+spring.liquibase.enabled=true
+spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.xml

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="001" author="dev">
+        <sql>
+            CREATE TABLE poder
+            (
+                poder_id   BIGINT NOT NULL AUTO_INCREMENT,
+                name_poder VARCHAR(255) DEFAULT NULL,
+                total_value_spent DOUBLE NOT NULL,
+                percentage_of_total DOUBLE NOT NULL,
+                PRIMARY KEY (poder_id)
+            );
+        </sql>
+    </changeSet>
+
+    <changeSet id="002" author="dev">
+        <sql>
+            CREATE TABLE ministerio
+            (
+                ministerio_id   BIGINT NOT NULL AUTO_INCREMENT,
+                name_ministerio VARCHAR(255) DEFAULT NULL,
+                poder_id        BIGINT       DEFAULT NULL,
+                total_value_spent DOUBLE NOT NULL,
+                percentage_of_total DOUBLE NOT NULL,
+                PRIMARY KEY (ministerio_id),
+                KEY             poder_id (poder_id),
+                CONSTRAINT ministerio_ibfk_1 FOREIGN KEY (poder_id) REFERENCES poder (poder_id)
+            );
+        </sql>
+    </changeSet>
+
+    <changeSet id="003" author="dev">
+        <sql>
+            CREATE TABLE orgao
+            (
+                orgao_id      BIGINT NOT NULL AUTO_INCREMENT,
+                name_orgao    VARCHAR(255) DEFAULT NULL,
+                ministerio_id BIGINT       DEFAULT NULL,
+                total_value_spent DOUBLE NOT NULL,
+                percentage_of_total DOUBLE NOT NULL,
+                PRIMARY KEY (orgao_id),
+                KEY           ministerio_id (ministerio_id),
+                CONSTRAINT orgao_ibfk_1 FOREIGN KEY (ministerio_id) REFERENCES ministerio (ministerio_id)
+            );
+        </sql>
+    </changeSet>
+
+    <changeSet id="004" author="dev">
+        <sql>
+            CREATE TABLE unidade_gestora
+            (
+                unidade_gestora_id   BIGINT NOT NULL AUTO_INCREMENT,
+                name_unidade_gestora VARCHAR(255) DEFAULT NULL,
+                orgao_id             BIGINT       DEFAULT NULL,
+                total_value_spent DOUBLE NOT NULL,
+                percentage_of_total DOUBLE NOT NULL,
+                PRIMARY KEY (unidade_gestora_id),
+                KEY                  orgao_id (orgao_id),
+                CONSTRAINT unidade_gestora_ibfk_1 FOREIGN KEY (orgao_id) REFERENCES orgao (orgao_id)
+            );
+        </sql>
+    </changeSet>
+
+    <changeSet id="005" author="dev">
+        <sql>
+            CREATE TABLE elemento_despesa
+            (
+                elemento_despesa_id   BIGINT NOT NULL AUTO_INCREMENT,
+                name_elemento_despesa VARCHAR(255) DEFAULT NULL,
+                unidade_gestora_id    BIGINT       DEFAULT NULL,
+                total_value_spent DOUBLE NOT NULL,
+                percentage_of_total DOUBLE NOT NULL,
+                PRIMARY KEY (elemento_despesa_id),
+                KEY                   unidade_gestora_id (unidade_gestora_id),
+                CONSTRAINT elemento_despesa_ibfk_1 FOREIGN KEY (unidade_gestora_id) REFERENCES unidade_gestora (unidade_gestora_id)
+            );
+        </sql>
+    </changeSet>
+
+    <changeSet id="006" author="dev">
+        <sql>
+            CREATE TABLE gasto_total
+            (
+                gasto_total_id BIGINT NOT NULL AUTO_INCREMENT,
+                gasto_total_value DOUBLE NOT NULL,
+                PRIMARY KEY (gasto_total_id)
+            );
+        </sql>
+    </changeSet>
+
+    <changeSet id="007" author="dev">
+        <sql>
+            CREATE TABLE despesa_simplificada
+            (
+                despesa_simplificada_id   BIGINT NOT NULL AUTO_INCREMENT,
+                despesa_simplificada_name VARCHAR(255) DEFAULT NULL,
+                despesa_simplificada_total_value DOUBLE NOT NULL,
+                despesa_simplificada_percentage_of_total DOUBLE NOT NULL,
+                PRIMARY KEY (despesa_simplificada_id)
+            );
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -7,18 +7,33 @@
 
     <changeSet id="001" author="dev">
         <sql>
-            CREATE TABLE poder
+            CREATE TABLE unidade_federativa
             (
-                poder_id   BIGINT NOT NULL AUTO_INCREMENT,
-                name_poder VARCHAR(255) DEFAULT NULL,
-                total_value_spent DOUBLE NOT NULL,
-                percentage_of_total DOUBLE NOT NULL,
-                PRIMARY KEY (poder_id)
+                unidade_federativa_id   bigint NOT NULL AUTO_INCREMENT,
+                name_unidade_federativa varchar(255) DEFAULT NULL,
+                total_value_spent double NOT NULL,
+                PRIMARY KEY (unidade_federativa_id)
             );
         </sql>
     </changeSet>
 
     <changeSet id="002" author="dev">
+        <sql>
+            CREATE TABLE poder
+            (
+                poder_id              bigint NOT NULL AUTO_INCREMENT,
+                name_poder            varchar(255) DEFAULT NULL,
+                unidade_federativa_id bigint       DEFAULT NULL,
+                total_value_spent double NOT NULL,
+                percentage_of_total double NOT NULL,
+                PRIMARY KEY (poder_id),
+                KEY                   unidade_federativa_id (unidade_federativa_id),
+                CONSTRAINT poder_ibfk_1 FOREIGN KEY (unidade_federativa_id) REFERENCES unidade_federativa (unidade_federativa_id)
+            );
+        </sql>
+    </changeSet>
+
+    <changeSet id="003" author="dev">
         <sql>
             CREATE TABLE ministerio
             (
@@ -34,7 +49,7 @@
         </sql>
     </changeSet>
 
-    <changeSet id="003" author="dev">
+    <changeSet id="004" author="dev">
         <sql>
             CREATE TABLE orgao
             (
@@ -50,7 +65,7 @@
         </sql>
     </changeSet>
 
-    <changeSet id="004" author="dev">
+    <changeSet id="005" author="dev">
         <sql>
             CREATE TABLE unidade_gestora
             (
@@ -66,7 +81,7 @@
         </sql>
     </changeSet>
 
-    <changeSet id="005" author="dev">
+    <changeSet id="006" author="dev">
         <sql>
             CREATE TABLE elemento_despesa
             (
@@ -82,7 +97,7 @@
         </sql>
     </changeSet>
 
-    <changeSet id="006" author="dev">
+    <changeSet id="007" author="dev">
         <sql>
             CREATE TABLE gasto_total
             (
@@ -93,7 +108,7 @@
         </sql>
     </changeSet>
 
-    <changeSet id="007" author="dev">
+    <changeSet id="008" author="dev">
         <sql>
             CREATE TABLE despesa_simplificada
             (


### PR DESCRIPTION
O intuito desse MR é facilitar a criação de tabelas e views através do versionamento do liquibase. Basta adicionar blocos de changeset's no arquivo `db/changelog-master.xml` e tabelas que não foram criadas vão ser criadas, todo histórico fica armazenado na tabela `DATABASECHANGELOG`. Não é necessário usar o dump.sql, basta o database estar criado ao rodar a aplicação.